### PR TITLE
fix: don't set Authorization header if token is not provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 4.4.5
+  - 8.16.1
 
 cache:
   directories:

--- a/dist/index.js
+++ b/dist/index.js
@@ -83,8 +83,9 @@ var accessToken = interceptor({
     var _parse = parse(_request.path),
         pathname = _parse.pathname;
 
-    if (needsAccessToken(pathname) === true) {
-      _request.headers = updateHeaders(_request, _request.accessToken || config.token);
+    var token = _request.accessToken || config.token;
+    if (token && needsAccessToken(pathname) === true) {
+      _request.headers = updateHeaders(_request, token);
     }
 
     return _request;

--- a/interceptor/accessToken.js
+++ b/interceptor/accessToken.js
@@ -28,8 +28,9 @@ export default interceptor({
   request (request, config) {
     const { pathname } = parse(request.path)
 
-    if (needsAccessToken(pathname) === true) {
-      request.headers = updateHeaders(request, request.accessToken || config.token)
+    const token = request.accessToken || config.token
+    if (token && needsAccessToken(pathname) === true) {
+      request.headers = updateHeaders(request, token)
     }
 
     return request

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ava": "0.15.2",
     "babel-eslint": "6.0.4",
     "babel-preset-es2015": "6.9.0",
-    "babel-preset-es2015-rollup": "1.1.1",
+    "babel-preset-es2015-rollup": "1.2.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "6.9.0",
     "nock": "8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,7 +513,7 @@ babel-plugin-espower@^2.1.0:
     espurify "^1.6.0"
     estraverse "^4.1.1"
 
-babel-plugin-external-helpers@^6:
+babel-plugin-external-helpers@^6.4.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
   integrity sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=
@@ -881,14 +881,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-es2015-rollup@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-1.1.1.tgz#2ee42781e8eb762f42054a1bdae62412de28f7f3"
-  integrity sha1-LuQngejrdi9CBUob2uYkEt4o9/M=
+babel-preset-es2015-rollup@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-1.2.0.tgz#feedf80346e01fa22d4de15e72cde1cefc59bf67"
+  integrity sha1-/u34A0bgH6ItTeFecs3hzvxZv2c=
   dependencies:
-    babel-plugin-external-helpers "^6"
-    babel-preset-es2015 "^6"
-    require-relative "^0.8.7"
+    babel-plugin-external-helpers "^6.4.0"
+    babel-preset-es2015 "^6.3.13"
+    modify-babel-preset "^2.1.1"
 
 babel-preset-es2015@6.9.0:
   version "6.9.0"
@@ -917,7 +917,7 @@ babel-preset-es2015@6.9.0:
     babel-plugin-transform-es2015-unicode-regex "^6.3.13"
     babel-plugin-transform-regenerator "^6.9.0"
 
-babel-preset-es2015@^6, babel-preset-es2015@^6.3.13:
+babel-preset-es2015@^6.3.13:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   integrity sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=
@@ -2853,6 +2853,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+modify-babel-preset@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/modify-babel-preset/-/modify-babel-preset-2.1.1.tgz#2d3190162ee62fb67aaa3325c242f026322ebbac"
+  integrity sha1-LTGQFi7mL7Z6qjMlwkLwJjIuu6w=
+  dependencies:
+    require-relative "^0.8.7"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
API endpoints that do not require access token still throw 401 when `Authorization: Bearer undefined` is sent, which is the case when `accessToken` is missing in the store.

Had to update a module and node.js version in travis config along the way - otherwise it does not build / pass CI.